### PR TITLE
Compilation and test on windows with msvc toolchain

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,11 @@ on: push
 name: CI
 jobs:
   build_and_test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
     steps:
       - uses: actions/checkout@v2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ edition = "2018"
 
 [build-dependencies]
 cmake = "0.1.44"
+
+[dev-dependencies]
+approx = "0.4"

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 fn main() {
     let dst = cmake::Config::new("./nlopt-2.5.0")
         .define("BUILD_SHARED_LIBS", "OFF")
@@ -13,5 +15,7 @@ fn main() {
     // Lib could be in either of two locations
     println!("cargo:rustc-link-search=native={}/lib", dst.display());
     println!("cargo:rustc-link-search=native={}/lib64", dst.display());
-    // println!("cargo:rustc-link-lib=static=nlopt");
+    if env::var("CARGO_CFG_TARGET_ENV").unwrap() == "msvc" {
+        println!("cargo:rustc-link-lib=static=nlopt");
+    }
 }

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,14 @@
 fn main() {
     let dst = cmake::Config::new("./nlopt-2.5.0")
         .define("BUILD_SHARED_LIBS", "OFF")
-        .define("CMAKE_CXX_COMPILER", "c++") // Not used
-        // The default C++ flags mess things up - override them
-        .define("CMAKE_CXX_FLAGS", "")
+        .define("CMAKE_CXX_COMPILER", "c++")
+        .define("NLOPT_CXX", "OFF")
+        .define("NLOPT_PYTHON", "OFF")
+        .define("NLOPT_OCTAVE", "OFF")
+        .define("NLOPT_MATLAB", "OFF")
+        .define("NLOPT_GUILE", "OFF")
+        .define("NLOPT_SWIG", "OFF")
+        .define("NLOPT_LINK_PYTHON", "OFF")
         .build();
     // Lib could be in either of two locations
     println!("cargo:rustc-link-search=native={}/lib", dst.display());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -855,6 +855,7 @@ pub fn approximate_gradient(x0: &[f64], f: fn(&[f64]) -> f64, grad: &mut [f64]) 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_abs_diff_eq;
 
     #[test]
     fn test_approx_gradient() {
@@ -987,8 +988,9 @@ mod tests {
 
         let mut input = vec![1., 1.];
         let (_s, v) = opt.optimize(&mut input).unwrap();
-        assert_eq!(v, 1.3934640682303436);
-        assert_eq!(&input, &[0.8228760595426139, 0.9114376093794901]);
+        assert_abs_diff_eq!(v, 1.3934640682303436, epsilon = 1e-6);
+        let expected = vec![0.8228760595426139, 0.9114376093794901];
+        assert_abs_diff_eq!(expected.as_slice(), input.as_slice(), epsilon = 1e-6);
     }
 
     #[test]
@@ -1022,16 +1024,18 @@ mod tests {
             3,
             |r: &mut [f64], x: &[f64], _: Option<&mut [f64]>, _: &mut ()| m_ineq_constraint(r, x),
             (),
-            &[1e-6;3],
-        ).unwrap();
+            &[1e-6; 3],
+        )
+        .unwrap();
 
         // TODO if we use two eq constraints, it doesn't converge *shrug*
         opt.add_equality_mconstraint(
             1,
             |r: &mut [f64], x: &[f64], _: Option<&mut [f64]>, _: &mut ()| m_eq_constraint(r, x),
             (),
-            &[1e-6;1],
-        ).unwrap();
+            &[1e-6; 1],
+        )
+        .unwrap();
 
         opt.set_xtol_rel(1e-6).unwrap();
 


### PR DESCRIPTION
This PR enables nlopt compilation on rust msvc toolchain on Windows:
* disable unrequired NlOpt bindings, specially CXX
* add static link option when using msvc
* fix a test as results are slightly different (diff < 1e-6) on windows (add approx dev-dependency)
* add windows testing in CI