### PR TITLE
Corrected documentation of MObjFn. 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,7 @@ type ConstraintCfg<F, T> = FunctionCfg<F, T>;
 
 /// A trait representing a multi-objective function.
 ///
-/// A multi-objective function takes the form of a closure `f(result: &mut [f64], x: &[f64], gradient: Option<&mut [f64], user_data: &mut U) -> f64`
+/// A multi-objective function takes the form of a closure `f(result: &mut [f64], x: &[f64], gradient: Option<&mut [f64], user_data: &mut U)`
 ///
 /// * `result` - `m`-dimensional array to store the value `f(x)`
 /// * `x` - `n`-dimensional array


### PR DESCRIPTION
Deleted the false documentation statement that a MObjFn returns a f64. It does not return an f64, as the return values are passed as function parameters.