### PR TITLE
fix(build.rs): don't override CMAKE_CXX_COMPILER, cross-compile would never work

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,6 @@
 fn main() {
     let dst = cmake::Config::new("./nlopt-2.9.1")
         .define("BUILD_SHARED_LIBS", "OFF")
-        .define("CMAKE_CXX_COMPILER", "c++")
         .define("NLOPT_CXX", "OFF")
         .define("NLOPT_PYTHON", "OFF")
         .define("NLOPT_OCTAVE", "OFF")


### PR DESCRIPTION
Please merge this patch, since cross-compiling now can not and does not work.